### PR TITLE
fix: perp link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ All deployments are on Polygon mainnet.
 
 | Contract | Audit | Deployment |
 | ----------- | ----------- | ----------- |
-| [Perps](https://github.com/Polymarket/perps) | [Quantstamp](./audit-reports/perps_quantstamp_20260408_20260410.pdf), [Cantina](./audit-reports/perps_cantina_20260424_20260501.pdf), [Certora](./audit-reports/perps_certora_20260427_20260428.pdf) | [0xdca4af75705dbb50f62437045aff9921947917d2](https://polygonscan.com/address/0xdca4af75705dbb50f62437045aff9921947917d2) |
+| [Perps](https://github.com/Polymarket/perpetuals-contract) | [Quantstamp](./audit-reports/perps_quantstamp_20260408_20260410.pdf), [Cantina](./audit-reports/perps_cantina_20260424_20260501.pdf), [Certora](./audit-reports/perps_certora_20260427_20260428.pdf) | [0xdca4af75705dbb50f62437045aff9921947917d2](https://polygonscan.com/address/0xdca4af75705dbb50f62437045aff9921947917d2) |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link correction with no on-chain or application code impact.
> 
> **Overview**
> Updates the **Perps** row in `README.md` so the contract name links to **`https://github.com/Polymarket/perpetuals-contract`** instead of **`https://github.com/Polymarket/perps`**. Audit report links and the Polygon deployment address are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63f43ece54bab5b4358cbdaa159d751719284139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->