### PR TITLE
S/add perps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ All deployments are on Polygon mainnet.
 
 | Contract | Audit | Deployment |
 | ----------- | ----------- | ----------- |
-| [Perps](https://github.com/Polymarket/perps) | [Quantstamp](./audit-reports/perps_quantstamp_20260408_20260410.pdf), [Cantina](./audit-reports/perps_cantina_20260424_20260501.pdf), [Certora](./audit-reports/perps_certora_20260427_20260428.pdf) | [0xdca4af75705dbb50f62437045aff9921947917d2](https://polygonscan.com/address/0xdca4af75705dbb50f62437045aff9921947917d2) |
+| [Perps](https://github.com/Polymarket/perpetuals-contract) | [Quantstamp](./audit-reports/perps_quantstamp_20260408_20260410.pdf), [Cantina](./audit-reports/perps_cantina_20260424_20260501.pdf), [Certora](./audit-reports/perps_certora_20260427_20260428.pdf) | [0xdca4af75705dbb50f62437045aff9921947917d2](https://polygonscan.com/address/0xdca4af75705dbb50f62437045aff9921947917d2) |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only URL correction with no on-chain or application code impact.
> 
> **Overview**
> Updates the **Perps** row in `README.md` so the contract source link points to **`Polymarket/perpetuals-contract`** instead of **`Polymarket/perps`**. Audit report links and the Polygon deployment address are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83d236d5920ee891cc7d4d68095cb02b9cef5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->